### PR TITLE
Only create storage folder if it is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,14 +23,21 @@ const LIST_OF_URLS = ["https://gun-manhattan.herokuapp.com/gun",
 "https://fire-gun.herokuapp.com/gun"]
 
 const STORAGE_FOLDER = path.resolve('./storage')
-
-if(!fs.existsSync('./storage')){
-    fs.mkdirSync('./storage')
+const DEFAULT_OPTS = {
+    peers: LIST_OF_URLS,
+    file: STORAGE_FOLDER
 }
 
-module.exports = function makeGunFetch(opts = null){
+module.exports = function makeGunFetch(opts = {}){
+    const finalOpts = {...DEFAULT_OPTS, ...opts}
 
-    const gun = Gun(opts || {peers: LIST_OF_URLS, file: STORAGE_FOLDER})
+    const fileLocation = finalOpts.file
+
+    if(fileLocation && (!fs.existsSync(fileLocation)) {
+        fs.mkdirSync('./storage')
+    }
+
+    const gun = Gun(finalOpts)
 
     const SUPPORTED_METHODS = ['GET', 'PUT', 'DELETE', 'POST', 'PATCH']
     const encodeType = '-'

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function makeGunFetch(opts = {}){
     const fileLocation = finalOpts.file
 
     if(fileLocation && (!fs.existsSync(fileLocation)) {
-        fs.mkdirSync('./storage')
+        fs.mkdirSync(fileLocation)
     }
 
     const gun = Gun(finalOpts)


### PR DESCRIPTION
At the moment `gun-fetch` will create a `storage` folder in the current working directory regardless of what the `file` option got set to.

This change delays creating the folder until the options are resolved.

This also accounts for cases where one of `peers` or `file` is specified in the `opts` so that the other default value will still get specified.